### PR TITLE
Setup updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ version = '0.1'
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 
 setup(
-    name='warrant',
+    name='notthatwarrant',
     version=version,
     description=README,
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip._internal.req import parse_requirements
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)
 
-version = '0.6.1'
+version = '0.1'
 
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='opensource@capless.io',
     maintainer='Brian Jinwright',
     packages=find_packages(),
-    url='https://github.com/capless/warrant',
+    url='https://github.com/ArcadiaPower/warrant',
     license='Apache License 2.0',
     install_requires=[str(ir.requirement) for ir in install_reqs],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ version = '0.1'
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 
 setup(
-    name='notthatwarrant',
+    name='apwarrant',
     version=version,
     description=README,
     long_description=README,


### PR DESCRIPTION
aws sam does some interesting things with installs. It pulls binaries to install packages first (from maybe its own stash of them?) rather than install from your fork of the repo. It looks up those binaries by name, so here we are forced to change the name in `setup()` to something other than just `warrant` so it will actually install the changes from this repo.